### PR TITLE
Additional mime type checking at motor.web.GridFSHandler

### DIFF
--- a/motor/web.py
+++ b/motor/web.py
@@ -17,6 +17,7 @@
 import datetime
 import email.utils
 import time
+import mimetypes
 
 import tornado.web
 from tornado import gen
@@ -97,6 +98,10 @@ class GridFSHandler(tornado.web.RequestHandler):
         self.set_header("Etag", '"%s"' % gridout.md5)
 
         mime_type = gridout.content_type
+
+        # If content type is not defiend, try to check it with mimetypes
+        if mime_type is None:
+            mime_type, encoding = mimetypes.guess_type(path)
 
         # Starting from here, largely a copy of StaticFileHandler
         if mime_type:


### PR DESCRIPTION
When `gridout.content_type` is `None` check content type like [tornado.web.StaticFileHandler](https://github.com/facebook/tornado/blob/master/tornado/web.py#L1614).
