### PR TITLE
Fix required PyMongo version

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -18,7 +18,7 @@ Prerequisites
 * Although Motor works with PyPy 2.0-beta1, limitations with greenlets and
   PyPy's JIT compiler make PyPy applications that use Motor too slow for
   regular use
-* PyMongo_ 2.5 or later
+* PyMongo_ 2.5.1 or later
 * Tornado_
 * Greenlet_
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pymongo>=2.5
+pymongo>=2.5.1
 tornado>=3
 greenlet>=0.4

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(name='motor',
       author_email='jesse@10gen.com',
       url='https://github.com/mongodb/motor/',
       install_requires=[
-          'pymongo >= 2.5',
+          'pymongo >= 2.5.1',
           'tornado >= 3',
           'greenlet >= 0.4.0',
       ],


### PR DESCRIPTION
Hi Jesse,

According to your indications in the mailling list of Tornado, the next version released will be compatible only with later versions or equal to 2.5.1 from PyMongo.
