### PR TITLE
Remove asynchronous decorator on GridFSHandler

### DIFF
--- a/motor/web.py
+++ b/motor/web.py
@@ -87,7 +87,6 @@ class GridFSHandler(tornado.web.RequestHandler):
         """
         return fs.get_last_version(path)  # A Future MotorGridOut
 
-    @tornado.web.asynchronous
     @gen.coroutine
     def get(self, path, include_body=True):
         fs = motor.MotorGridFS(self.database, self.root_collection)


### PR DESCRIPTION
Since Tornado 3.1, `@asynchronous` decorator is not needed when using `@gen.coroutine`.
