### PR TITLE
Bump pymongo version to 2.7.2

### DIFF
--- a/motor/__init__.py
+++ b/motor/__init__.py
@@ -48,7 +48,7 @@ def get_version_string():
 version = get_version_string()
 """Current version of Motor."""
 
-expected_pymongo_version = '2.7.1'
+expected_pymongo_version = '2.7.2'
 if pymongo.version != expected_pymongo_version:
     msg = (
         "Motor %s requires PyMongo at exactly version %s. "

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(name='motor',
       install_requires=[
           'tornado >= 3.1',
           'greenlet >= 0.4.0',
-          'pymongo == 2.7.1',
+          'pymongo == 2.7.2',
       ],
       license='http://www.apache.org/licenses/LICENSE-2.0',
       classifiers=filter(None, classifiers.split('\n')),


### PR DESCRIPTION
PyMongo 2.7.2 has some bug fixes that would be nice to use. The "obscure connection pool semaphore leaks" fix would go nicely with the connection pool leak fix in 0.3.4

See the [PyMongo changelog](http://api.mongodb.org/python/current/changelog.html) for more details.
