### PR TITLE
Remove redundancy code.

### DIFF
--- a/motor/core.py
+++ b/motor/core.py
@@ -365,10 +365,6 @@ class MotorPool(object):
             if _closed(sock_info.sock):
                 sock_info.close()
                 error = True
-        elif time.time() - sock_info.last_checkout > 1:
-            if _closed(sock_info.sock):
-                sock_info.close()
-                error = True
 
         if not error:
             return sock_info


### PR DESCRIPTION
Line 368-371 is duplicated with line 364-367.

Note that there is still problem that `_closed()` will always return `False` in `asyncio` framework because `AsyncioMotorSocket.fileno()` is not implemented.