### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ asyncio. It requires:
 * `backports.pbkdf2`_ for faster authentication with MongoDB 3.0+,
   especially on Python older than 2.7.8, or on Python 3 before Python 3.4.
 
-See `requirements <http://motor.readthedocs.org/en/stable/requirements.html>`_
+See `requirements <https://motor.readthedocs.io/en/stable/requirements.html>`_
 for details about compatibility.
 
 How To Ask For Help
@@ -95,7 +95,7 @@ To build the documentation, install sphinx_ and do ``cd doc; make html``.
 Examples
 ========
 
-See the `examples on ReadTheDocs <https://motor.readthedocs.org/en/latest/examples/index.html>`_.
+See the `examples on ReadTheDocs <https://motor.readthedocs.io/en/latest/examples/index.html>`_.
 
 Testing
 =======
@@ -116,7 +116,7 @@ In Python 2.6, unittest2_ is automatically installed.
 
 .. _backports.pbkdf2: https://pypi.python.org/pypi/backports.pbkdf2/
 
-.. _ReadTheDocs: http://motor.readthedocs.org/
+.. _ReadTheDocs: https://motor.readthedocs.io/
 
 .. _mongodb-user list on Google Groups:
    https://groups.google.com/forum/?fromgroups#!forum/mongodb-user

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,7 @@ Motor presents a callback- or Future-based API for non-blocking access to
 MongoDB from Tornado_ or asyncio_.
 
 The `source is on GitHub <https://github.com/mongodb/motor>`_ and
-the docs are on `ReadTheDocs <http://motor.readthedocs.org/>`_.
+the docs are on `ReadTheDocs <https://motor.readthedocs.io/>`_.
 
     "Motor uses a clever greenlet-based approach to fully support both
     synchronous and asynchronous interfaces from a single codebase. It's great

--- a/doc/tutorial-asyncio.rst
+++ b/doc/tutorial-asyncio.rst
@@ -541,7 +541,7 @@ the ``shutdown`` coroutine to attempt a graceful exit:
 
 The complete code is in the Motor repository in ``examples/aiohttp_example.py``.
 
-.. _aiohttp: https://aiohttp.readthedocs.org/
+.. _aiohttp: https://aiohttp.readthedocs.io/
 
 Further Reading
 ---------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Tox (http://tox.readthedocs.org) is a tool for running tests in multiple
+# Tox (https://tox.readthedocs.io) is a tool for running tests in multiple
 # virtualenvs. "pip install tox" and run "tox" from this directory.
 
 # Adapted from Tornado's tox.ini.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.