### PR TITLE
Fix Python 3.5 aggregate example

### DIFF
--- a/motor/core.py
+++ b/motor/core.py
@@ -568,7 +568,6 @@ class AgnosticCollection(AgnosticBaseProperties):
 
           async def f():
               async for doc in collection.aggregate(pipeline):
-                  doc = cursor.next_object()
                   print(doc)
 
         MongoDB versions 2.4 and older do not support aggregation cursors; use


### PR DESCRIPTION
After wondering why Python 3.5 aggregate example was printing `None`s, I figured out that it had an extra line that was wrong.