### PR TITLE
allow AgnosticCursor.collation to be called as chained method

### DIFF
--- a/motor/core.py
+++ b/motor/core.py
@@ -953,7 +953,7 @@ class AgnosticCursor(AgnosticBaseCursor):
     __delegate_class__ = Cursor
     address           = ReadOnlyProperty()
     count             = AsyncRead()
-    collation         = ReadOnlyProperty()
+    collation         = MotorCursorChainingMethod()
     distinct          = AsyncRead()
     explain           = AsyncRead()
     add_option        = MotorCursorChainingMethod()

--- a/test/tornado_tests/test_motor_cursor.py
+++ b/test/tornado_tests/test_motor_cursor.py
@@ -279,12 +279,15 @@ class MotorCursorTest(MotorMockServerTest):
 
     @gen_test
     def test_to_list_with_chained_collation(self):
+        if not (yield at_least(self.cx, (3, 4))):
+            raise SkipTest("collation requires MongoDB >= 3.4")
+
         yield self.make_test_data()
         cursor = self.collection.find({}, {'_id': 1}) \
             .sort([('_id', pymongo.ASCENDING)]) \
             .collation(Collation("en"))
         expected = [{'_id': i} for i in range(200)]
-        (result, error), _ = yield gen.Task(cursor.to_list, length=1000)
+        result = yield cursor.to_list(length=1000)
         self.assertEqual(expected, result)
 
     @gen_test


### PR DESCRIPTION
AgnosticCursor::collation can't be called as chained method

```python
db["test_collection"].find({}).sort("field").collation(Collation("pl")).to_list(length=1)
```

This PR resolves bug https://jira.mongodb.org/browse/MOTOR-154