### PR TITLE
Fix causal consistency example.

### DIFF
--- a/motor/docstrings.py
+++ b/motor/docstrings.py
@@ -1003,8 +1003,8 @@ This method takes the same parameters as PyMongo's
   
       with (await client.start_session()) as s:
           doc = {'_id': ObjectId(), 'x': 1}
-          await collection.insert(doc)
-  
+          await collection.insert(doc, session=s)
+
           secondary = collection.with_options(
               read_preference=ReadPreference.SECONDARY)
   


### PR DESCRIPTION
By default, operations are only casually consistent within the same session. The `insert` must use the same session as the `find`.