### PR TITLE
Add optional dependencies, forwarding them to pymongo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,10 @@ setup(name='motor',
       author_email='jesse@mongodb.com',
       url='https://github.com/mongodb/motor/',
       install_requires=install_requires,
+      extras_require={
+        key: 'pymongo[{}]'.format(key)
+        for key in ('tls', 'srv', 'gssapi')
+      },
       license='http://www.apache.org/licenses/LICENSE-2.0',
       classifiers=[c for c in classifiers.split('\n') if c],
       keywords=[


### PR DESCRIPTION
`pymongo` supports three optional dependencies, it would be nice to support them as well here, so that we can depend directly on `motor[srv]` instead of having to list both `motor` and `pymongo[srv]`