### PR TITLE
Add 'mongo_client' argument to AgnosticClient

### DIFF
--- a/motor/core.py
+++ b/motor/core.py
@@ -138,7 +138,11 @@ class AgnosticClient(AgnosticBaseProperties):
             'driver',
             DriverInfo('Motor', motor_version, self._framework.platform_info()))
 
-        delegate = self.__delegate_class__(*args, **kwargs)
+        if 'mongo_client' in kwargs:
+            delegate = kwargs.pop('mongo_client')
+        else:
+            delegate = self.__delegate_class__(*args, **kwargs)
+
         super(AgnosticBaseProperties, self).__init__(delegate)
         self.io_loop = io_loop
 

--- a/test/asyncio_tests/test_asyncio_client.py
+++ b/test/asyncio_tests/test_asyncio_client.py
@@ -86,6 +86,13 @@ class TestAsyncIOClient(AsyncIOTestCase):
             yield from client.admin.command('ismaster')
         client.close()
 
+    def test_mongo_client(self):
+        cx = self.asyncio_client()
+
+        client = motor_asyncio.AsyncIOMotorClient(mongo_client=cx.delegate)
+
+        self.assertIs(client.delegate, cx.delegate)
+
     def test_database_named_delegate(self):
         self.assertTrue(
             isinstance(self.cx.delegate, pymongo.mongo_client.MongoClient))

--- a/test/tornado_tests/test_motor_client.py
+++ b/test/tornado_tests/test_motor_client.py
@@ -87,6 +87,13 @@ class MotorClientTest(MotorTest):
         with self.assertRaises(TypeError):
             motor.MotorClient(test.env.uri, io_loop='foo')
 
+    def test_mongo_client(self):
+        cx = self.motor_client()
+
+        client = motor.MotorClient(mongo_client=cx.delegate)
+
+        self.assertIs(client.delegate, cx.delegate)
+
     def test_database_named_delegate(self):
         self.assertTrue(
             isinstance(self.cx.delegate, pymongo.mongo_client.MongoClient))


### PR DESCRIPTION
This change adds a new `mongo_client` argument when creating a new `MotorClient` or `AsyncIOMotorClient` instance, setting the delegate object to a pre-existing `MongoClient` instead of creating a new instance.

**Background**

I help maintain a project that uses Motor and has a very large number of tests, the majority of which involve MongoDB accesses. These tests use Tornado's `AsyncTestCase` and create new `MotorClient` instances in their `setUp` methods. As the tests run, they become progressively slower and, especially on weaker computers, eventually hang. Attaching a debugger to the hung Python process shows that there are a large number of active threads, the number roughly corresponding to the number of `MotorClient` instances that were created, thus far. These threads appear to be running the PyMongo `_process_periodic_tasks` code run through the periodic executor.

To avoid the hanging issue and improve overall test performance, we would like to be able to re-use the same `MotorClient` instance in all tests that need database access but, since `MotorClient` needs an IO loop and Tornado's `AsyncTestCase` creates a new IO loop for each test, that does not appear possible. A decent alternative is to re-use a single `MongoClient` instance for all tests and pass that `MongoClient` when creating a new `MotorClient` in the `setUp` method.