### PR TITLE
MOTOR-488 Don't call set_result on a cancelled tasks

### DIFF
--- a/motor/core.py
+++ b/motor/core.py
@@ -1538,6 +1538,9 @@ class _LatentCursor(object):
     _CommandCursor__killed = False
     cursor_id = None
 
+    def _CommandCursor__end_session(self, *args, **kwargs):
+        pass
+
     def _CommandCursor__die(self, *args, **kwargs):
         pass
 

--- a/motor/core.py
+++ b/motor/core.py
@@ -1356,13 +1356,13 @@ class AgnosticBaseCursor(AgnosticBase):
         return future
 
     def _to_list(self, length, the_list, future, get_more_result):
-        # Return early if the task was cancelled.
-        if future.done():
-            return
         # get_more_result is the result of self._get_more().
         # to_list_future will be the result of the user's to_list() call.
         try:
             result = get_more_result.result()
+            # Return early if the task was cancelled.
+            if future.done():
+                return
             collection = self.collection
             fix_outgoing = collection.database.delegate._fix_outgoing
 
@@ -1384,7 +1384,8 @@ class AgnosticBaseCursor(AgnosticBase):
                     self._get_more(),
                     self._to_list, length, the_list, future)
         except Exception as exc:
-            future.set_exception(exc)
+            if not future.done():
+                future.set_exception(exc)
 
     def get_io_loop(self):
         return self.collection.get_io_loop()
@@ -1592,9 +1593,6 @@ class AgnosticLatentCommandCursor(AgnosticCommandCursor):
         return super(self.__class__, self)._get_more()
 
     def _on_started(self, original_future, future):
-        # Return early if the task was cancelled.
-        if original_future.done():
-            return
         try:
             # "result" is a PyMongo command cursor from PyMongo's aggregate() or
             # aggregate_raw_batches(). Set its batch size from our latent
@@ -1602,8 +1600,12 @@ class AgnosticLatentCommandCursor(AgnosticCommandCursor):
             pymongo_cursor = future.result()
             self.delegate = pymongo_cursor
         except Exception as exc:
-            original_future.set_exception(exc)
+            if not original_future.done():
+                original_future.set_exception(exc)
         else:
+            # Return early if the task was cancelled.
+            if original_future.done():
+                return
             if self.delegate._CommandCursor__data or not self.delegate.alive:
                 # _get_more is complete.
                 original_future.set_result(

--- a/motor/frameworks/asyncio/__init__.py
+++ b/motor/frameworks/asyncio/__init__.py
@@ -89,6 +89,9 @@ def chain_return_value(future, loop, return_value):
     chained = asyncio.Future(loop=loop)
 
     def copy(_future):
+        # Return early if the task was cancelled.
+        if chained.done():
+            return
         if _future.exception() is not None:
             chained.set_exception(_future.exception())
         else:

--- a/motor/frameworks/tornado/__init__.py
+++ b/motor/frameworks/tornado/__init__.py
@@ -72,6 +72,9 @@ def chain_return_value(future, loop, return_value):
     chained = concurrent.Future()
 
     def copy(_future):
+        # Return early if the task was cancelled.
+        if chained.done():
+            return
         if _future.exception() is not None:
             chained.set_exception(_future.exception())
         else:

--- a/test/asyncio_tests/__init__.py
+++ b/test/asyncio_tests/__init__.py
@@ -199,7 +199,8 @@ def asyncio_test(func=None, timeout=None):
 
             def exc_handler(loop, context):
                 nonlocal coro_exc
-                coro_exc = context['exception']
+                # Exception is optional.
+                coro_exc = context.get('exception', Exception(context))
 
                 # Raise CancelledError from run_until_complete below.
                 task.cancel()

--- a/test/utils.py
+++ b/test/utils.py
@@ -124,3 +124,18 @@ def get_async_test_timeout(default=5):
         return max(timeout, default)
     except (ValueError, TypeError):
         return default
+
+
+class FailPoint:
+    def __init__(self, client, command_args):
+        self.client = client
+        self.cmd_on = SON([('configureFailPoint', 'failCommand')])
+        self.cmd_on.update(command_args)
+
+    async def __aenter__(self):
+        await self.client.admin.command(self.cmd_on)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.client.admin.command(
+            'configureFailPoint', self.cmd_on['configureFailPoint'],
+            mode='off')


### PR DESCRIPTION
This change prevents Motor from failing with `asyncio.exceptions.InvalidStateError: invalid state` when tasks are cancelled by the application.

