### PR TITLE
MOTOR-538 Revise issues and help sections of documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,10 @@ Think you’ve found a bug? Want to see a new feature in Motor? Please open a
 case in our issue management tool, JIRA:
 
 - `Create an account and login <https://jira.mongodb.org>`_.
-- Navigate to `the PYTHON project <https://jira.mongodb.org/browse/MOTOR>`_.
+- Navigate to `the MOTOR project <https://jira.mongodb.org/browse/MOTOR>`_.
 - Click **Create Issue** - Please provide as much information as possible about the issue type and how to reproduce it.
 
-Bug reports in JIRA for all driver projects (i.e. PYTHON, CSHARP, JAVA) and the
+Bug reports in JIRA for all driver projects (i.e. MOTOR, CSHARP, JAVA) and the
 Core Server (i.e. SERVER) project are **public**.
 
 How To Ask For Help

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Forums <https://developer.mongodb.com/community/forums/tag/motor-driver>`_.
 Bugs / Feature Requests
 =======================
 
-Think you’ve found a bug? Want to see a new feature in Motor? Please open a
+Think you've found a bug? Want to see a new feature in Motor? Please open a
 case in our issue management tool, JIRA:
 
 - `Create an account and login <https://jira.mongodb.org>`_.
@@ -80,7 +80,7 @@ Please include all of the following information when opening an issue:
 Security Vulnerabilities
 ------------------------
 
-If you’ve identified a security vulnerability in a driver or any other
+If you've identified a security vulnerability in a driver or any other
 MongoDB project, please report it according to the `instructions here
 <http://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@ Motor
 
 :Info: Motor is a full-featured, non-blocking MongoDB_ driver for Python
     Tornado_ and asyncio_ applications.
+:Documentation: Available at `motor.readthedocs.io <https://motor.readthedocs.io/en/stable/>`_
 :Author: A\. Jesse Jiryu Davis
 
 About
@@ -30,10 +31,69 @@ and the docs are on ReadTheDocs_.
 
     --*Ryan Smith, inXus Interactive*
 
+Support / Feedback
+==================
+
+For issues with, questions about, or feedback for PyMongo, please look into
+our `support channels <https://support.mongodb.com/welcome>`_. Please
+do not email any of the Motor developers directly with issues or
+questions - you're more likely to get an answer on the `MongoDB Community
+Forums <https://developer.mongodb.com/community/forums/tag/motor-driver>`_.
+
+Bugs / Feature Requests
+=======================
+
+Think you’ve found a bug? Want to see a new feature in Motor? Please open a
+case in our issue management tool, JIRA:
+
+- `Create an account and login <https://jira.mongodb.org>`_.
+- Navigate to `the PYTHON project <https://jira.mongodb.org/browse/MOTOR>`_.
+- Click **Create Issue** - Please provide as much information as possible about the issue type and how to reproduce it.
+
+Bug reports in JIRA for all driver projects (i.e. PYTHON, CSHARP, JAVA) and the
+Core Server (i.e. SERVER) project are **public**.
+
+How To Ask For Help
+-------------------
+
+Please include all of the following information when opening an issue:
+
+- Detailed steps to reproduce the problem, including full traceback, if possible.
+- The exact python version used, with patch level::
+
+  $ python -c "import sys; print(sys.version)"
+
+- The exact version of Motor used, with patch level::
+
+  $ python -c "import motor; print(motor.version)"
+
+- The exact version of PyMongo used, with patch level::
+
+  $ python -c "import pymongo; print(pymongo.version); print(pymongo.has_c())"
+
+- The exact Tornado version, if you are using Tornado::
+
+  $ python -c "import tornado; print(tornado.version)"
+
+- The operating system and version (e.g. RedHat Enterprise Linux 6.4, OSX 10.9.5, ...)
+
+Security Vulnerabilities
+------------------------
+
+If you’ve identified a security vulnerability in a driver or any other
+MongoDB project, please report it according to the `instructions here
+<http://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report>`_.
+
 Installation
 ============
 
+Motor can be installed with `pip <http://pypi.python.org/pypi/pip>`_::
+
   $ pip install motor
+
+You can also download the project source and do::
+
+  $ python setup.py install
 
 Dependencies
 ============
@@ -48,45 +108,18 @@ asyncio. It requires:
 See `requirements <https://motor.readthedocs.io/en/stable/requirements.html>`_
 for details about compatibility.
 
-How To Ask For Help
-===================
+Examples
+========
 
-Issues with, questions about, or feedback for Motor should be sent to the
-`MongoDB Community Forums`_.
-
-For confirmed issues or feature requests,
-open a case in `Jira <http://jira.mongodb.org>`_ in the "MOTOR" project.
-Please include all of the following information:
-
-- Detailed steps to reproduce the problem, including your code and a full
-  traceback, if possible.
-- What you expected to happen, and what actually happened.
-- The exact python version used, with patch level::
-
-  $ python -c "import sys; print(sys.version)"
-
-- The exact version of PyMongo used::
-
-  $ python -c "import pymongo; print(pymongo.version); print(pymongo.has_c())"
-
-- The exact Tornado version, if you are using Tornado::
-
-  $ python -c "import tornado; print(tornado.version)"
-
-- The operating system and version (e.g. RedHat Enterprise Linux 6.4, OSX 10.9.5, ...)
+See the `examples on ReadTheDocs <https://motor.readthedocs.io/en/stable/examples/index.html>`_.
 
 Documentation
 =============
 
 Motor's documentation is on ReadTheDocs_.
 
-Build the documentation with Python 3.5. Install sphinx, Tornado, and aiohttp,
+Build the documentation with Python 3.5. Install sphinx_, Tornado_, and aiohttp_,
 and do ``cd doc; make html``.
-
-Examples
-========
-
-See the `examples on ReadTheDocs <https://motor.readthedocs.io/en/latest/examples/index.html>`_.
 
 Testing
 =======
@@ -102,9 +135,8 @@ Tests are located in the ``test/`` directory.
 
 .. _asyncio: https://docs.python.org/3/library/asyncio.html
 
-.. _ReadTheDocs: https://motor.readthedocs.io/
+.. _aiohttp: https://github.com/aio-libs/aiohttp
 
-.. _MongoDB Community Forums:
-   https://community.mongodb.com/tags/c/drivers-odms-connectors/7/motor-driver
+.. _ReadTheDocs: https://motor.readthedocs.io/en/stable/
 
 .. _sphinx: http://sphinx.pocoo.org/

--- a/README.rst
+++ b/README.rst
@@ -91,10 +91,6 @@ Motor can be installed with `pip <http://pypi.python.org/pypi/pip>`_::
 
   $ pip install motor
 
-You can also download the project source and do::
-
-  $ python setup.py install
-
 Dependencies
 ============
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,14 +36,38 @@ Install with::
 
 .. _asyncio: https://docs.python.org/3/library/asyncio.html
 
-How To Ask For Help
--------------------
+Getting Help
+------------
+If you're having trouble or have questions about Motor, ask your question on
+our `MongoDB Community Forum <https://developer.mongodb.com/community/forums/tags/c/drivers-odms-connectors/7/motor-driver>`_.
+You may also want to consider a
+`commercial support subscription <https://support.mongodb.com/welcome>`_.
+Once you get an answer, it'd be great if you could work it back into this
+documentation and contribute!
 
-Post questions about Motor to the
-`MongoDB Community Forums
-<https://community.mongodb.com/tags/c/drivers-odms-connectors/7/motor-driver>`_.
-For confirmed issues or feature requests, open a case in
-`Jira <http://jira.mongodb.org>`_ in the "MOTOR" project.
+Issues
+------
+All issues should be reported (and can be tracked / voted for /
+commented on) at the main `MongoDB JIRA bug tracker
+<http://jira.mongodb.org/browse/MOTOR>`_, in the "Motor"
+project.
+
+Feature Requests / Feedback
+---------------------------
+Use our `feedback engine <https://feedback.mongodb.com/forums/924286-drivers>`_
+to send us feature requests and general feedback about PyMongo.
+
+Contributing
+------------
+**Motor** has a large :doc:`community <contributors>` and
+contributions are always encouraged. Contributions can be as simple as
+minor tweaks to this documentation. To contribute, fork the project on
+`GitHub <http://github.com/mongodb/motor/>`_ and send a
+pull request.
+
+Changes
+-------
+See the :doc:`changelog` for a full list of changes to Motor.
 
 Contents
 --------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -3,10 +3,14 @@ Installation
 
 Install Motor from PyPI_ with pip_::
 
-  $ python -m pip install motor
+  $ python3 -m pip install motor
 
 Pip automatically installs Motor's prerequisite packages.
 See :doc:`requirements`.
+
+To install Motor from sources, you can clone its git repository do::
+
+  $ python3 -m pip install .
 
 .. _PyPI: http://pypi.python.org/pypi/motor
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,7 +8,7 @@ Install Motor from PyPI_ with pip_::
 Pip automatically installs Motor's prerequisite packages.
 See :doc:`requirements`.
 
-To install Motor from sources, you can clone its git repository do::
+To install Motor from sources, you can clone its git repository and do::
 
   $ python3 -m pip install .
 


### PR DESCRIPTION
I made changes to make the Readme and documentation index page consistent with that of PyMongo - I think this will make it more maintainable in the long run. If you don't share this opinion, I can make surgical changes and leave in place the old language and structure.