### PR TITLE
MOTOR-320 Create ChangeStream cursor in async with __aenter__

### DIFF
--- a/motor/core.py
+++ b/motor/core.py
@@ -1758,11 +1758,14 @@ class AgnosticChangeStream(AgnosticBase):
     __anext__ = next
 
     async def __aenter__(self):
+        if not self.delegate:
+            loop = self.get_io_loop()
+            await self._framework.run_on_executor(loop, self._lazy_init)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.delegate:
-            self.delegate.close()
+            await self.close()
 
     def get_io_loop(self):
         return self._target.get_io_loop()

--- a/motor/core.py
+++ b/motor/core.py
@@ -1666,6 +1666,9 @@ class AgnosticChangeStream(AgnosticBase):
         self._lazy_init()
         return self.delegate.try_next()
 
+    async def _run_on_executor(self, func):
+        return await self._framework.run_on_executor(self.get_io_loop(), func)
+
     async def next(self):
         """Advance the cursor.
 
@@ -1704,8 +1707,7 @@ class AgnosticChangeStream(AgnosticBase):
         example above, you can also iterate the change stream by calling
         ``await change_stream.next()`` repeatedly.
         """
-        loop = self.get_io_loop()
-        return await self._framework.run_on_executor(loop, self._next)
+        return await self._run_on_executor(self._next)
 
     async def try_next(self):
         """Advance the cursor without blocking indefinitely.
@@ -1741,8 +1743,7 @@ class AgnosticChangeStream(AgnosticBase):
 
         .. versionadded:: 2.1
         """
-        loop = self.get_io_loop()
-        return await self._framework.run_on_executor(loop, self._try_next)
+        return await self._run_on_executor(self._try_next)
 
     async def close(self):
         """Close this change stream.
@@ -1759,8 +1760,7 @@ class AgnosticChangeStream(AgnosticBase):
 
     async def __aenter__(self):
         if not self.delegate:
-            loop = self.get_io_loop()
-            await self._framework.run_on_executor(loop, self._lazy_init)
+            await self._run_on_executor(self._lazy_init)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/motor/core.py
+++ b/motor/core.py
@@ -1666,9 +1666,6 @@ class AgnosticChangeStream(AgnosticBase):
         self._lazy_init()
         return self.delegate.try_next()
 
-    async def _run_on_executor(self, func):
-        return await self._framework.run_on_executor(self.get_io_loop(), func)
-
     async def next(self):
         """Advance the cursor.
 
@@ -1707,7 +1704,8 @@ class AgnosticChangeStream(AgnosticBase):
         example above, you can also iterate the change stream by calling
         ``await change_stream.next()`` repeatedly.
         """
-        return await self._run_on_executor(self._next)
+        loop = self.get_io_loop()
+        return await self._framework.run_on_executor(loop, self._next)
 
     async def try_next(self):
         """Advance the cursor without blocking indefinitely.
@@ -1743,7 +1741,8 @@ class AgnosticChangeStream(AgnosticBase):
 
         .. versionadded:: 2.1
         """
-        return await self._run_on_executor(self._try_next)
+        loop = self.get_io_loop()
+        return await self._framework.run_on_executor(loop, self._try_next)
 
     async def close(self):
         """Close this change stream.
@@ -1760,7 +1759,8 @@ class AgnosticChangeStream(AgnosticBase):
 
     async def __aenter__(self):
         if not self.delegate:
-            await self._run_on_executor(self._lazy_init)
+            loop = self.get_io_loop()
+            await self._framework.run_on_executor(loop, self._lazy_init)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/test/asyncio_tests/test_asyncio_change_stream.py
+++ b/test/asyncio_tests/test_asyncio_change_stream.py
@@ -211,6 +211,18 @@ class TestAsyncIOChangeStream(AsyncIOTestCase):
         self.assertFalse(change_stream.delegate._cursor.alive)
 
     @asyncio_test
+    async def test_async_with_creates_cursor(self):
+        coll = self.collection
+        await coll.insert_one({'_id': 1})
+        async with coll.watch() as stream:
+            self.assertEqual([{'_id': 1}],
+                             await coll.find().to_list(None))
+            await coll.insert_one({'_id': 2})
+            doc = await stream.try_next()
+            self.assertIsNotNone(doc)
+            self.assertEqual({'_id': 2}, doc['fullDocument'])
+
+    @asyncio_test
     async def test_with_statement(self):
         with self.assertRaises(RuntimeError):
             with self.collection.watch():

--- a/test/asyncio_tests/test_asyncio_change_stream.py
+++ b/test/asyncio_tests/test_asyncio_change_stream.py
@@ -218,8 +218,7 @@ class TestAsyncIOChangeStream(AsyncIOTestCase):
             self.assertEqual([{'_id': 1}],
                              await coll.find().to_list(None))
             await coll.insert_one({'_id': 2})
-            doc = await stream.try_next()
-            self.assertIsNotNone(doc)
+            doc = await stream.next()
             self.assertEqual({'_id': 2}, doc['fullDocument'])
 
     @asyncio_test


### PR DESCRIPTION
This change makes motor's ChangeStream work more like PyMongo's by establishing the server-side cursor earlier. PyMongo creates the cursor in the call to `watch()`. To do that in Motor we would need to make `watch` async  (`def watch(...)` -> `async def watch(...)`) which is a backward breaking change. Instead, Prashant had the clever idea to create the cursor in `__aenter__`. This will resolve the user's complaint in https://jira.mongodb.org/browse/MOTOR-320.