### PR TITLE
BUMP 2.3.0.dev0

### DIFF
--- a/motor/__init__.py
+++ b/motor/__init__.py
@@ -14,7 +14,7 @@
 
 """Motor, an asynchronous driver for MongoDB."""
 
-version_tuple = (2, 2, 0)
+version_tuple = (2, 3, 0, 'dev0')
 
 
 def get_version_string():

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ packages = ['motor', 'motor.frameworks', 'motor.frameworks.tornado',
 
 
 setup(name='motor',
-      version='2.2.0',
+      version='2.3.0.dev0',
       packages=packages,
       description=description,
       long_description=long_description,


### PR DESCRIPTION
Ignore the branch name - I followed what was done in https://github.com/mongodb/motor/commit/dad11a56537e0282c9b91d38a86a3b8adb817388 and bumped the minor version instead of the patch version. 