### PR TITLE
MOTOR-613: Add contextvars support

### DIFF
--- a/motor/frameworks/asyncio/__init__.py
+++ b/motor/frameworks/asyncio/__init__.py
@@ -29,6 +29,12 @@ from asyncio import coroutine  # For framework interface.
 from concurrent.futures import ThreadPoolExecutor
 
 
+try:
+    import contextvars
+except ImportError:
+    contextvars = None
+
+
 CLASS_PREFIX = 'AsyncIO'
 
 
@@ -60,6 +66,10 @@ _EXECUTOR = ThreadPoolExecutor(max_workers=max_workers)
 
 
 def run_on_executor(loop, fn, *args, **kwargs):
+    if contextvars:
+        context = contextvars.copy_context()
+        fn = functools.partial(context.run, fn)
+
     return loop.run_in_executor(
         _EXECUTOR, functools.partial(fn, *args, **kwargs))
 

--- a/motor/frameworks/tornado/__init__.py
+++ b/motor/frameworks/tornado/__init__.py
@@ -27,6 +27,12 @@ from tornado import concurrent, gen, ioloop, version as tornado_version
 from tornado.gen import chain_future, coroutine  # For framework interface.
 
 
+try:
+    import contextvars
+except ImportError:
+    contextvars = None
+
+
 CLASS_PREFIX = ''
 
 
@@ -57,6 +63,10 @@ _EXECUTOR = ThreadPoolExecutor(max_workers=max_workers)
 
 
 def run_on_executor(loop, fn, *args, **kwargs):
+    if contextvars:
+        context = contextvars.copy_context()
+        fn = functools.partial(context.run, fn)
+
     return loop.run_in_executor(
         _EXECUTOR, functools.partial(fn, *args, **kwargs))
 


### PR DESCRIPTION
Add support to context vars.

This may be useful for logging, e.g. pass trace params like request_id to CommandLogger