### PR TITLE
MOTOR-613 Test contextvars support

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,29 @@ Changelog
 
 .. currentmodule:: motor.motor_tornado
 
+Motor 2.3
+---------
+
+Motor 2.3 adds support for contextvars.
+
+New features:
+
+- Added supported for the contextvars module. Specifically, it is now possible
+  to access context variables inside
+  :class:`~pymongo.monitoring.CommandListener` callbacks.
+
+Bug-fixes:
+
+-
+
+Issues Resolved
+~~~~~~~~~~~~~~~
+
+See the `Motor 2.3 release notes in JIRA`_ for the complete list of resolved
+issues in this release.
+
+.. _Motor 2.3 release notes in JIRA: https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=11182&version=29749
+
 Motor 2.2
 ---------
 

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -12,3 +12,4 @@ The following is a list of people who have contributed to
 - Nikolay Novik
 - Prashant Mital
 - Shane Harvey
+- Bulat Khasanov

--- a/test/asyncio_tests/test_asyncio_client.py
+++ b/test/asyncio_tests/test_asyncio_client.py
@@ -223,14 +223,14 @@ class TestAsyncIOClient(AsyncIOTestCase):
     @unittest.skipIf(not contextvars, 'this test requires contextvars')
     @asyncio_test
     async def test_contextvars_support(self):
-        contextvar = contextvars.ContextVar('variable', default='default')
+        var = contextvars.ContextVar('variable', default='default')
 
         class Listener(monitoring.CommandListener):
             def __init__(self):
-                self.vars = []
+                self.values = []
 
             def save_contextvar_value(self):
-                self.vars.append(contextvar.get())
+                self.values.append(var.get())
 
             def started(self, event):
                 self.save_contextvar_value()
@@ -239,24 +239,24 @@ class TestAsyncIOClient(AsyncIOTestCase):
                 self.save_contextvar_value()
 
             def failed(self, event):
-                self.save_contextvar_value()
+                pass
 
         listener = Listener()
         client = self.asyncio_client(event_listeners=[listener])
         coll = client[self.db.name].test
 
         await coll.insert_one({})
-        self.assertTrue(listener.vars)
-        for var in listener.vars:
-            self.assertEqual(var, 'default')
+        self.assertTrue(listener.values)
+        for val in listener.values:
+            self.assertEqual(val, 'default')
 
-        contextvar.set('ContextVar value')
-        listener.vars.clear()
+        var.set('ContextVar value')
+        listener.values.clear()
 
         await coll.insert_one({})
-        self.assertTrue(listener.vars)
-        for var in listener.vars:
-            self.assertEqual(var, 'ContextVar value')
+        self.assertTrue(listener.values)
+        for val in listener.values:
+            self.assertEqual(val, 'ContextVar value')
 
 
 class TestAsyncIOClientTimeout(AsyncIOMockServerTestCase):


### PR DESCRIPTION
Added a test case inspired by the example in https://github.com/mongodb/motor/pull/88.