### PR TITLE
MOTOR-476: Update FLE documentation for community version demonstrating explicit encryption/decryption

### DIFF
--- a/doc/api-asyncio/asyncio_motor_client_encryption.rst
+++ b/doc/api-asyncio/asyncio_motor_client_encryption.rst
@@ -1,0 +1,11 @@
+:class:`~motor.motor_asyncio.AsyncIOMotorClientEncryption` -- Connection to MongoDB
+=========================================================================
+
+.. autoclass:: motor.motor_asyncio.AsyncIOMotorClient
+  :members:
+
+  .. describe:: client[db_name] || client.db_name
+
+     Get the `db_name` :class:`AsyncIOMotorDatabase` on :class:`AsyncIOMotorClient` `client`.
+
+     Raises :class:`~pymongo.errors.InvalidName` if an invalid database name is used.

--- a/doc/examples/auto_csfle_example.py
+++ b/doc/examples/auto_csfle_example.py
@@ -4,15 +4,15 @@ import asyncio
 from bson.codec_options import CodecOptions
 from bson import json_util
 
-from motor.motor_asyncio import AsyncIOMotorClient
-from pymongo.encryption import (Algorithm,
-                                ClientEncryption)
+from motor.motor_asyncio import (AsyncIOMotorClient,
+                                 AsyncIOMotorClientEncryption)
+from pymongo.encryption import Algorithm
 from pymongo.encryption_options import AutoEncryptionOpts
 
 
-def create_json_schema_file(kms_providers, key_vault_namespace,
+async def create_json_schema_file(kms_providers, key_vault_namespace,
                             key_vault_client):
-    client_encryption = ClientEncryption(
+    client_encryption = AsyncIOMotorClientEncryption(
         kms_providers,
         key_vault_namespace,
         key_vault_client,
@@ -25,7 +25,7 @@ def create_json_schema_file(kms_providers, key_vault_namespace,
 
     # Create a new data key and json schema for the encryptedField.
     # https://dochub.mongodb.org/core/client-side-field-level-encryption-automatic-encryption-rules
-    data_key_id = client_encryption.create_data_key(
+    data_key_id = await client_encryption.create_data_key(
         'local', key_alt_names=['pymongo_encryption_example_1'])
     schema = {
         "properties": {
@@ -74,7 +74,7 @@ async def main():
         unique=True,
         partialFilterExpression={"keyAltNames": {"$exists": True}})
 
-    create_json_schema_file(
+    await create_json_schema_file(
         kms_providers, key_vault_namespace, key_vault_client)
 
     # Load the JSON Schema and construct the local schema_map option.

--- a/doc/examples/auto_csfle_example.py
+++ b/doc/examples/auto_csfle_example.py
@@ -18,7 +18,7 @@ async def create_json_schema_file(kms_providers, key_vault_namespace,
         key_vault_client,
         # The CodecOptions class used for encrypting and decrypting.
         # This should be the same CodecOptions instance you have configured
-        # on MongoClient, Database, or Collection. We will not be calling
+        # on MotorClient, Database, or Collection. We will not be calling
         # encrypt() or decrypt() in this example so we can use any
         # CodecOptions.
         CodecOptions())
@@ -64,7 +64,7 @@ async def main():
     key_vault_namespace = "encryption.__pymongoTestKeyVault"
     key_vault_db_name, key_vault_coll_name = key_vault_namespace.split(".", 1)
 
-    # The MongoClient used to access the key vault (key_vault_namespace).
+    # The MotorClient used to access the key vault (key_vault_namespace).
     key_vault_client = AsyncIOMotorClient()
     key_vault = key_vault_client[key_vault_db_name][key_vault_coll_name]
     # Ensure that two data keys cannot share the same keyAltName.

--- a/doc/examples/encryption.rst
+++ b/doc/examples/encryption.rst
@@ -98,3 +98,27 @@ data key and create a collection with the
 
 .. literalinclude:: server_fle_enforcement_example.py
   :language: python3
+
+.. _explicit-client-side-encryption:
+
+Explicit Encryption
+~~~~~~~~~~~~~~~~~~~
+
+Explicit encryption is a MongoDB community feature and does not use the
+``mongocryptd`` process. Explicit encryption is provided by the
+:class:`~pymongo.encryption.ClientEncryption` class, for example:
+
+.. literalinclude:: explicit_encryption_example.py
+  :language: python3
+
+Explicit Encryption with Automatic Decryption
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Although automatic encryption requires MongoDB 4.2 enterprise or a
+MongoDB 4.2 Atlas cluster, automatic *decryption* is supported for all users.
+To configure automatic *decryption* without automatic *encryption* set
+``bypass_auto_encryption=True`` in
+:class:`~pymongo.encryption_options.AutoEncryptionOpts`::
+
+.. literalinclude:: explicit_encryption_automatic_decryption_example.py
+  :language: python3

--- a/doc/examples/encryption.rst
+++ b/doc/examples/encryption.rst
@@ -118,7 +118,7 @@ Although automatic encryption requires MongoDB 4.2 enterprise or a
 MongoDB 4.2 Atlas cluster, automatic *decryption* is supported for all users.
 To configure automatic *decryption* without automatic *encryption* set
 ``bypass_auto_encryption=True`` in
-:class:`~pymongo.encryption_options.AutoEncryptionOpts`::
+:class:`~pymongo.encryption_options.AutoEncryptionOpts`:
 
 .. literalinclude:: explicit_encryption_automatic_decryption_example.py
   :language: python3

--- a/doc/examples/encryption.rst
+++ b/doc/examples/encryption.rst
@@ -47,11 +47,11 @@ Automatic Client-Side Field Level Encryption
 --------------------------------------------
 
 Automatic client-side field level encryption is enabled by creating a
-:class:`~pymongo.mongo_client.MongoClient` with the ``auto_encryption_opts``
+:class:`~motor.motor_asyncio.AsyncIOMotorClient` with the ``auto_encryption_opts``
 option set to an instance of
 :class:`~pymongo.encryption_options.AutoEncryptionOpts`. The following
 examples show how to setup automatic client-side field level encryption
-using :class:`~pymongo.encryption.ClientEncryption` to create a new
+using :class:`~motor.motor_asyncio.AsyncIOMotorClientEncryption` to create a new
 encryption data key.
 
 .. note:: Automatic client-side field level encryption requires MongoDB 4.2+
@@ -106,7 +106,7 @@ Explicit Encryption
 
 Explicit encryption is a MongoDB community feature and does not use the
 ``mongocryptd`` process. Explicit encryption is provided by the
-:class:`~pymongo.encryption.ClientEncryption` class, for example:
+:class:`~motor.motor_asyncio.AsyncIOMotorClientEncryption` class, for example:
 
 .. literalinclude:: explicit_encryption_example.py
   :language: python3

--- a/doc/examples/explicit_encryption_automatic_decryption_example.py
+++ b/doc/examples/explicit_encryption_automatic_decryption_example.py
@@ -41,12 +41,12 @@ async def main():
     client_encryption = AsyncIOMotorClientEncryption(
         kms_providers,
         key_vault_namespace,
-        # The MongoClient to use for reading/writing to the key vault.
-        # This can be the same MongoClient used by the main application.
+        # The MotorClient to use for reading/writing to the key vault.
+        # This can be the same MotorClient used by the main application.
         client,
         # The CodecOptions class used for encrypting and decrypting.
         # This should be the same CodecOptions instance you have configured
-        # on MongoClient, Database, or Collection.
+        # on MotorClient, Database, or Collection.
         coll.codec_options)
 
     # Create a new data key for the encryptedField.

--- a/doc/examples/explicit_encryption_automatic_decryption_example.py
+++ b/doc/examples/explicit_encryption_automatic_decryption_example.py
@@ -1,0 +1,73 @@
+import os
+
+from motor.motor_asyncio import (AsyncIOMotorClient,
+                                 AsyncIOMotorClientEncryption)
+from pymongo.encryption import Algorithm
+from pymongo.encryption_options import AutoEncryptionOpts
+
+
+def main():
+    # This must be the same master key that was used to create
+    # the encryption key.
+    local_master_key = os.urandom(96)
+    kms_providers = {"local": {"key": local_master_key}}
+
+    # The MongoDB namespace (db.collection) used to store
+    # the encryption data keys.
+    key_vault_namespace = "encryption.__pymongoTestKeyVault"
+    key_vault_db_name, key_vault_coll_name = key_vault_namespace.split(".", 1)
+
+    # bypass_auto_encryption=True disable automatic encryption but keeps
+    # the automatic _decryption_ behavior. bypass_auto_encryption will
+    # also disable spawning mongocryptd.
+    auto_encryption_opts = AutoEncryptionOpts(
+        kms_providers, key_vault_namespace, bypass_auto_encryption=True)
+
+    client = AsyncIOMotorClient(auto_encryption_opts=auto_encryption_opts)
+    coll = client.test.coll
+    # Clear old data
+    await coll.drop()
+
+    # Set up the key vault (key_vault_namespace) for this example.
+    key_vault = client[key_vault_db_name][key_vault_coll_name]
+    # Ensure that two data keys cannot share the same keyAltName.
+    await key_vault.drop()
+    await key_vault.create_index(
+        "keyAltNames",
+        unique=True,
+        partialFilterExpression={"keyAltNames": {"$exists": True}})
+
+    client_encryption = AsyncIOMotorClientEncryption(
+        kms_providers,
+        key_vault_namespace,
+        # The MongoClient to use for reading/writing to the key vault.
+        # This can be the same MongoClient used by the main application.
+        client,
+        # The CodecOptions class used for encrypting and decrypting.
+        # This should be the same CodecOptions instance you have configured
+        # on MongoClient, Database, or Collection.
+        coll.codec_options)
+
+    # Create a new data key for the encryptedField.
+    data_key_id = await client_encryption.create_data_key(
+        'local', key_alt_names=['pymongo_encryption_example_4'])
+
+    # Explicitly encrypt a field:
+    encrypted_field = await client_encryption.encrypt(
+        "123456789",
+        Algorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic,
+        key_alt_name='pymongo_encryption_example_4')
+    await coll.insert_one({"encryptedField": encrypted_field})
+    # Automatically decrypts any encrypted fields.
+    doc = await coll.find_one()
+    print('Decrypted document: %s' % (doc,))
+    unencrypted_coll = AsyncIOMotorClient().test.coll
+    print('Encrypted document: %s' % (await unencrypted_coll.find_one(),))
+
+    # Cleanup resources.
+    await client_encryption.close()
+    await client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/examples/explicit_encryption_example.py
+++ b/doc/examples/explicit_encryption_example.py
@@ -17,7 +17,7 @@ async def main():
   key_vault_namespace = "encryption.__pymongoTestKeyVault"
   key_vault_db_name, key_vault_coll_name = key_vault_namespace.split(".", 1)
 
-  # The MongoClient used to read/write application data.
+  # The MotorClient used to read/write application data.
   client = AsyncIOMotorClient()
   coll = client.test.coll
   # Clear old data
@@ -35,12 +35,12 @@ async def main():
   client_encryption = AsyncIOMotorClientEncryption(
       kms_providers,
       key_vault_namespace,
-      # The MongoClient to use for reading/writing to the key vault.
-      # This can be the same MongoClient used by the main application.
+      # The Motorlient to use for reading/writing to the key vault.
+      # This can be the same MotorClient used by the main application.
       client,
       # The CodecOptions class used for encrypting and decrypting.
       # This should be the same CodecOptions instance you have configured
-      # on MongoClient, Database, or Collection.
+      # on MotorClient, Database, or Collection.
       coll.codec_options)
 
   # Create a new data key for the encryptedField.

--- a/doc/examples/explicit_encryption_example.py
+++ b/doc/examples/explicit_encryption_example.py
@@ -1,0 +1,68 @@
+import os
+
+from motor.motor_asyncio import (AsyncIOMotorClient,
+                                 AsyncIOMotorClientEncryption)
+from pymongo.encryption import Algorithm
+
+
+def main():
+  # This must be the same master key that was used to create
+  # the encryption key.
+  local_master_key = os.urandom(96)
+  kms_providers = {"local": {"key": local_master_key}}
+
+  # The MongoDB namespace (db.collection) used to store
+  # the encryption data keys.
+  key_vault_namespace = "encryption.__pymongoTestKeyVault"
+  key_vault_db_name, key_vault_coll_name = key_vault_namespace.split(".", 1)
+
+  # The MongoClient used to read/write application data.
+  client = AsyncIOMotorClient()
+  coll = client.test.coll
+  # Clear old data
+  await coll.drop()
+
+  # Set up the key vault (key_vault_namespace) for this example.
+  key_vault = client[key_vault_db_name][key_vault_coll_name]
+  # Ensure that two data keys cannot share the same keyAltName.
+  await key_vault.drop()
+  await key_vault.create_index(
+      "keyAltNames",
+      unique=True,
+      partialFilterExpression={"keyAltNames": {"$exists": True}})
+
+  client_encryption = AsyncIOMotorClientEncryption(
+      kms_providers,
+      key_vault_namespace,
+      # The MongoClient to use for reading/writing to the key vault.
+      # This can be the same MongoClient used by the main application.
+      client,
+      # The CodecOptions class used for encrypting and decrypting.
+      # This should be the same CodecOptions instance you have configured
+      # on MongoClient, Database, or Collection.
+      coll.codec_options)
+
+  # Create a new data key for the encryptedField.
+  data_key_id = await client_encryption.create_data_key(
+      'local', key_alt_names=['pymongo_encryption_example_3'])
+
+  # Explicitly encrypt a field:
+  encrypted_field = await client_encryption.encrypt(
+      "123456789",
+      Algorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic,
+      key_id=data_key_id)
+  await coll.insert_one({"encryptedField": encrypted_field})
+  doc = await coll.find_one()
+  print('Encrypted document: %s' % (doc,))
+
+  # Explicitly decrypt the field:
+  doc["encryptedField"] = await client_encryption.decrypt(doc["encryptedField"])
+  print('Decrypted document: %s' % (doc,))
+
+  # Cleanup resources.
+  await client_encryption.close()
+  await client.close()
+
+
+if __name__ == "__main__":
+  main()

--- a/doc/examples/jsonSchema.json
+++ b/doc/examples/jsonSchema.json
@@ -1,1 +1,0 @@
-{"properties": {"encryptedField": {"encrypt": {"keyId": [{"$binary": {"base64": "8ZqGtL9cQ5eyUvh5BRMlsw==", "subType": "04"}}], "bsonType": "string", "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"}}}, "bsonType": "object"}

--- a/doc/examples/jsonSchema.json
+++ b/doc/examples/jsonSchema.json
@@ -1,0 +1,1 @@
+{"properties": {"encryptedField": {"encrypt": {"keyId": [{"$binary": {"base64": "8ZqGtL9cQ5eyUvh5BRMlsw==", "subType": "04"}}], "bsonType": "string", "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"}}}, "bsonType": "object"}

--- a/doc/examples/server_fle_enforcement_example.py
+++ b/doc/examples/server_fle_enforcement_example.py
@@ -4,9 +4,9 @@ import asyncio
 from bson.codec_options import CodecOptions
 from bson.binary import STANDARD
 
-from motor.motor_asyncio import AsyncIOMotorClient
-from pymongo.encryption import (Algorithm,
-                                ClientEncryption)
+from motor.motor_asyncio import (AsyncIOMotorClient,
+                                 AsyncIOMotorClientEncryption)
+from pymongo.encryption import Algorithm
 from pymongo.encryption_options import AutoEncryptionOpts
 from pymongo.errors import OperationFailure
 from pymongo.write_concern import WriteConcern
@@ -37,7 +37,7 @@ async def main():
         unique=True,
         partialFilterExpression={"keyAltNames": {"$exists": True}})
 
-    client_encryption = ClientEncryption(
+    client_encryption = AsyncIOMotorClientEncryption(
         kms_providers,
         key_vault_namespace,
         key_vault_client,
@@ -49,7 +49,7 @@ async def main():
         CodecOptions())
 
     # Create a new data key and json schema for the encryptedField.
-    data_key_id = client_encryption.create_data_key(
+    data_key_id = await client_encryption.create_data_key(
         'local', key_alt_names=['pymongo_encryption_example_2'])
     json_schema = {
         "properties": {

--- a/doc/examples/server_fle_enforcement_example.py
+++ b/doc/examples/server_fle_enforcement_example.py
@@ -27,7 +27,7 @@ async def main():
     key_vault_namespace = "encryption.__pymongoTestKeyVault"
     key_vault_db_name, key_vault_coll_name = key_vault_namespace.split(".", 1)
 
-    # The MongoClient used to access the key vault (key_vault_namespace).
+    # The MotorClient used to access the key vault (key_vault_namespace).
     key_vault_client = AsyncIOMotorClient()
     key_vault = key_vault_client[key_vault_db_name][key_vault_coll_name]
     # Ensure that two data keys cannot share the same keyAltName.
@@ -43,7 +43,7 @@ async def main():
         key_vault_client,
         # The CodecOptions class used for encrypting and decrypting.
         # This should be the same CodecOptions instance you have configured
-        # on MongoClient, Database, or Collection. We will not be calling
+        # on MotorClient, Database, or Collection. We will not be calling
         # encrypt() or decrypt() in this example so we can use any
         # CodecOptions.
         CodecOptions())


### PR DESCRIPTION
Ported over examples for explicit encryption/decryption from PyMongo CSFLE. Built docs to check that they render correctly and ran each example to ensure that they work as expected.