### PR TITLE
MOTOR-607: Improve how we raise DeprecationWarnings in Motor

### DIFF
--- a/motor/core.py
+++ b/motor/core.py
@@ -56,8 +56,9 @@ except ImportError:
     ssl = None
     HAS_SSL = False
 
-# Surface deprecation warnings to users by default
-warnings.filterwarnings("default", category=DeprecationWarning)
+# Surface warnings to users by default
+if not sys.warnoptions:
+    warnings.simplefilter("default")
 
 # From the Convenient API for Transactions spec, with_transaction must
 # halt retries after 120 seconds.

--- a/motor/core.py
+++ b/motor/core.py
@@ -56,6 +56,9 @@ except ImportError:
     ssl = None
     HAS_SSL = False
 
+# Surface deprecation warnings to users by default
+warnings.filterwarnings("default", category=DeprecationWarning)
+
 # From the Convenient API for Transactions spec, with_transaction must
 # halt retries after 120 seconds.
 # This limit is non-configurable and was chosen to be twice the 60 second


### PR DESCRIPTION
Surface `DeprecationWarnings` to user without using python flags
```
(base) william.zhou@M-C02F15QFMD6M ~ % cat sample.py
import asyncio
from motor.motor_asyncio import AsyncIOMotorClient
 
async def main():
    client = AsyncIOMotorClient()
    print(await client.admin.command('ping'))
    print(client.nodes)
    await client.fsync()
 
asyncio.run(main())
(base) william.zhou@M-C02F15QFMD6M ~ % python sample.py    
{'ok': 1.0}
frozenset({('localhost', 27017)})
/Users/william.zhou/opt/anaconda3/lib/python3.8/concurrent/futures/thread.py:57: DeprecationWarning: fsync is deprecated. Use client.admin.command('fsync') instead.
  result = self.fn(*self.args, **self.kwargs)
(base) william.zhou@M-C02F15QFMD6M ~ % python -Wd sample.py
{'ok': 1.0}
frozenset({('localhost', 27017)})
/Users/william.zhou/opt/anaconda3/lib/python3.8/concurrent/futures/thread.py:57: DeprecationWarning: fsync is deprecated. Use client.admin.command('fsync') instead.
  result = self.fn(*self.args, **self.kwargs)
```