### PR TITLE
MOTOR-622: Add Python 3.9 support

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -777,6 +777,10 @@ axes:
         variables:
            TOX_ENV: "tornado6-py38"
            PYTHON_BINARY: "/opt/python/3.8/bin/python3"
+      - id: "tornado6-py39"
+        variables:
+           TOX_ENV: "tornado6-py38"
+           PYTHON_BINARY: "/opt/python/3.9/bin/python3"
       - id: "tornado_git-py35"
         variables:
            TOX_ENV: "tornado_git-py35"
@@ -813,6 +817,10 @@ axes:
         variables:
            TOX_ENV: "asyncio-py38"
            PYTHON_BINARY: "/opt/python/3.8/bin/python3"
+      - id: "asyncio-py38"
+        variables:
+           TOX_ENV: "asyncio-py38"
+           PYTHON_BINARY: "/opt/python/3.9/bin/python3"
       - id: "py3-pymongo-master"
         variables:
            TOX_ENV: "py3-pymongo-master"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -779,7 +779,7 @@ axes:
            PYTHON_BINARY: "/opt/python/3.8/bin/python3"
       - id: "tornado6-py39"
         variables:
-           TOX_ENV: "tornado6-py38"
+           TOX_ENV: "tornado6-py39"
            PYTHON_BINARY: "/opt/python/3.9/bin/python3"
       - id: "tornado_git-py35"
         variables:
@@ -817,9 +817,9 @@ axes:
         variables:
            TOX_ENV: "asyncio-py38"
            PYTHON_BINARY: "/opt/python/3.8/bin/python3"
-      - id: "asyncio-py38"
+      - id: "asyncio-py39"
         variables:
-           TOX_ENV: "asyncio-py38"
+           TOX_ENV: "asyncio-py39"
            PYTHON_BINARY: "/opt/python/3.9/bin/python3"
       - id: "py3-pymongo-master"
         variables:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 services: mongodb
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
 Operating System :: MacOS :: MacOS X
 Operating System :: Unix
 Operating System :: Microsoft :: Windows

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     tornado5-{pypy35,pypy36,py35,py36,py37},
 
     # Tornado 6 supports Python 3.5+.
-    tornado6-{pypy35,pypy36,py35,py36,py37,py38},
+    tornado6-{pypy35,pypy36,py35,py36,py37,py38,py39},
 
     # Test Tornado on master in a few configurations.
     tornado_git-{py35,py36,py37},
@@ -21,7 +21,7 @@ envlist =
     py3-sphinx-doctest,
 
     # asyncio without Tornado.
-    asyncio-{pypy35,pypy36,py35,py36,py37,py38},
+    asyncio-{pypy35,pypy36,py35,py36,py37,py38,py39},
 
     # Test PyMongo HEAD, not the latest release.
     py3-pymongo-master,
@@ -43,6 +43,7 @@ basepython =
     py36: {env:PYTHON_BINARY:python3.6}
     py37,synchro37: {env:PYTHON_BINARY:python3.7}
     py38: {env:PYTHON_BINARY:python3.8}
+    py39: {env:PYTHON_BINARY:python3.9}
     pypy35: {env:PYTHON_BINARY:pypy3}
     pypy36: {env:PYTHON_BINARY:pypy3}
 
@@ -54,7 +55,7 @@ deps =
     tornado6: tornado>=6,<7
     tornado_git: git+https://github.com/tornadoweb/tornado.git
 
-    {py35,py36,py37,py38}: aiohttp
+    {py35,py36,py37,py38,py39}: aiohttp
 
     sphinx: sphinx
     sphinx: aiohttp


### PR DESCRIPTION
Run Test suite on Python 3.9, add Python 3.9 to evergreen test matrix and travis builds