### PR TITLE
MOTOR-701: Require MongoDB 4.2+ to run CSFLE tests

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/test/asyncio_tests/test_asyncio_encryption.py
+++ b/test/asyncio_tests/test_asyncio_encryption.py
@@ -27,6 +27,7 @@ from motor.motor_asyncio import AsyncIOMotorClientEncryption
 
 from pymongo.encryption import Algorithm
 from pymongo.errors import InvalidOperation
+from test import env
 from test.asyncio_tests import (asyncio_test,
                                 AsyncIOTestCase,
                                 skip_if_mongos)
@@ -41,7 +42,7 @@ try:
 except ImportError:
     _HAVE_PYMONGOCRYPT = False
 
-
+@env.require_version_min(4,2,-1)
 class TestExplicitSimple(AsyncIOTestCase):
     def setUp(self):
         super().setUp()

--- a/test/asyncio_tests/test_asyncio_encryption.py
+++ b/test/asyncio_tests/test_asyncio_encryption.py
@@ -42,6 +42,7 @@ try:
 except ImportError:
     _HAVE_PYMONGOCRYPT = False
 
+
 @env.require_version_min(4,2,-1)
 class TestExplicitSimple(AsyncIOTestCase):
     def setUp(self):


### PR DESCRIPTION
Older versions of MDB do not support CSFLE, so require 4.2 version to run tests