### PR TITLE
MOTOR-703 Ensure we are testing against latest pymongo v3.12 commit

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -821,9 +821,9 @@ axes:
         variables:
            TOX_ENV: "asyncio-py39"
            PYTHON_BINARY: "/opt/python/3.9/bin/python3"
-      - id: "py3-pymongo-master"
+      - id: "py3-pymongo-v3.12"
         variables:
-           TOX_ENV: "py3-pymongo-master"
+           TOX_ENV: "py3-pymongo-v3.12"
            # Use 3.6 for now until 3.7 is on all Evergreen distros.
            PYTHON_BINARY: "/opt/python/3.6/bin/python3"
       - id: "synchro37"
@@ -897,7 +897,7 @@ buildvariants:
   display_name: "${os}-${tox-env}-${ssl}"
   matrix_spec:
     os: "rhel"
-    tox-env: ["tornado5-py36", "py3-pymongo-master"]
+    tox-env: ["tornado5-py36", "py3-pymongo-v3.12"]
     ssl: "*"
   tasks:
      - ".3.0"

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ envlist =
     asyncio-{pypy35,pypy36,py35,py36,py37,py38,py39},
 
     # Test PyMongo HEAD, not the latest release.
-    py3-pymongo-master,
+    py3-pymongo-v3.12,
 
     # Apply PyMongo's test suite to Motor via Synchro.
     synchro37
@@ -61,7 +61,6 @@ deps =
     sphinx: aiohttp
     sphinx: git+https://github.com/tornadoweb/tornado.git
 
-    py3-pymongo-master: git+https://github.com/mongodb/mongo-python-driver.git
     py3-pymongo-master: tornado>=5,<6
 
     synchro37: tornado>=6,<7
@@ -84,6 +83,12 @@ setenv = PYTHONHASHSEED=0
 changedir = doc
 commands =
     sphinx-build -q -E -b doctest . {envtmpdir}/doctest {posargs}
+
+[testenv:py3-pymongo-v3.12]
+commands =
+    pip install git+https://github.com/mongodb/mongo-python-driver.git#egg=pymongo[encryption]
+    python --version
+    python setup.py test --xunit-output=xunit-results {posargs}
 
 [testenv:synchro37]
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
     sphinx: aiohttp
     sphinx: git+https://github.com/tornadoweb/tornado.git
 
-    py3-pymongo-master: tornado>=5,<6
+    py3-pymongo-v3.12: tornado>=5,<6
 
     synchro37: tornado>=6,<7
     synchro37: nose
@@ -88,6 +88,7 @@ commands =
 commands =
     pip install git+https://github.com/mongodb/mongo-python-driver.git#egg=pymongo[encryption]
     python --version
+    python -c "import pymongo; print('PyMongo %s' % (pymongo.version,))"
     python setup.py test --xunit-output=xunit-results {posargs}
 
 [testenv:synchro37]

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ commands =
 
 [testenv:py3-pymongo-v3.12]
 commands =
-    pip install git+https://github.com/mongodb/mongo-python-driver.git#egg=pymongo[encryption]
+    pip install git+https://github.com/mongodb/mongo-python-driver.git@v3.12#egg=pymongo[encryption]
     python --version
     python -c "import pymongo; print('PyMongo %s' % (pymongo.version,))"
     python setup.py test --xunit-output=xunit-results {posargs}


### PR DESCRIPTION
We must override the PyMongo dependency as part of [tox commands](https://tox.readthedocs.io/en/latest/index.html#system-overview) to ensure the version specified in `install_requires` doesn't prevail. The `#egg=pymongo[encryption]` is required to pull in the `encryption` extra with the `pip git+` syntax.