### PR TITLE
(docs) fix broken link

### DIFF
--- a/doc/examples/monitoring.rst
+++ b/doc/examples/monitoring.rst
@@ -82,10 +82,10 @@ See also:
 * PyMongo's :mod:`~pymongo.monitoring` module
 * `The Command Monitoring Spec`_
 * `The Topology Monitoring Spec`_
-* The `monitoring.py`_ example file in the Motor repository
+* The `monitoring_example.py`_ example file in the Motor repository
 
 .. _The Command Monitoring Spec:
 .. _Command Monitoring: https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.rst
 .. _The Topology Monitoring Spec:
 .. _Topology Monitoring: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst
-.. _monitoring.py: https://github.com/mongodb/motor/blob/master/doc/examples/monitoring.py
+.. _monitoring.py: https://github.com/mongodb/motor/blob/master/doc/examples/monitoring_example.py


### PR DESCRIPTION
- Corrects name of Python file for the monitoring example