### PR TITLE
MOTOR-794 Fix support for Sphinx 4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -199,8 +199,10 @@ latex_documents = [
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-autodoc_default_flags = ['inherited-members']
-autodoc_member_order = 'groupwise'
+autodoc_default_options = {
+    'inherited-members': True,
+    'member-order': 'groupwise',
+}
 
 pymongo_inventory = ('https://pymongo.readthedocs.io/en/%s/' % pymongo_version,
                      None)


### PR DESCRIPTION
autodoc_default_flags has been deprecated since version 1.8. We need to use autodoc_default_options instead. See:
- https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_flags
- https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_options