### PR TITLE
MOTOR-805 Fix that the number of query results is inconsistent with the length argument when calling to_list().

### DIFF
--- a/motor/core.py
+++ b/motor/core.py
@@ -1424,7 +1424,7 @@ class AgnosticBaseCursor(AgnosticBase):
             if length is None:
                 n = result
             else:
-                n = min(length, result)
+                n = min(length - len(the_list), result)
 
             for _ in range(n):
                 the_list.append(fix_outgoing(self._data().popleft(),


### PR DESCRIPTION
1. Fix that the number of query results is inconsistent with the length argument when calling to_list().
2. Adding a test case named "A" to cover this case.