### PR TITLE
MOTOR-808 Fix test_watch_with_start_after on MongoDB 5.1+

### DIFF
--- a/test/asyncio_tests/test_asyncio_change_stream.py
+++ b/test/asyncio_tests/test_asyncio_change_stream.py
@@ -156,6 +156,9 @@ class TestAsyncIOChangeStream(AsyncIOTestCase):
         # Generate invalidate event and store corresponding resume token.
         await self.collection.drop()
         _ = await change_stream.next()
+        # v5.1 requires an extra getMore after an invalidate event to exhaust
+        # the cursor.
+        self.assertIsNone(await change_stream.try_next())
         self.assertFalse(change_stream.alive)
         resume_token = change_stream.resume_token
 

--- a/test/tornado_tests/test_motor_change_stream.py
+++ b/test/tornado_tests/test_motor_change_stream.py
@@ -143,6 +143,9 @@ class MotorChangeStreamTest(MotorTest):
         # Generate invalidate event and store corresponding resume token.
         await self.collection.drop()
         _ = await change_stream.next()
+        # v5.1 requires an extra getMore after an invalidate event to exhaust
+        # the cursor.
+        self.assertIsNone(await change_stream.try_next())
         self.assertFalse(change_stream.alive)
         resume_token = change_stream.resume_token
 


### PR DESCRIPTION
See the explanation in https://jira.mongodb.org/browse/MOTOR-808