### PR TITLE
MOTOR-884 Mirror all PyMongo extras

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,47 @@ asyncio. It requires:
 * PyMongo_ >=3.12,<4
 * Python 3.5+
 
+Optional dependencies:
+
+Motor supports same optional dependencies as PyMongo. Required dependencies can be installed 
+along with Motor.
+
+GSSAPI authentication requires pymongo[gssapi]. The correct
+dependency can be installed automatically along with Motor::
+
+  $ pip install "motor[gssapi]"
+
+similarly,
+
+MONGODB-AWS authentication requires pymongo[aws]::
+
+  $ pip install "motor[aws]"
+
+Support for mongodb+srv:// URIs requires pymongo[srv]::
+
+  $ pip install "motor[srv]"
+
+OCSP requires pymongo[ocsp]::
+
+  $ pip install "motor[ocsp]"
+
+Wire protocol compression with snappy requires pymongo[snappy]::
+
+  $ pip install "motor[snappy]"
+
+Wire protocol compression with zstandard requires pymongo[zstd]::
+
+  $ pip install "motor[zstd]"
+
+Client-Side Field Level Encryption requires pymongo[encryption]::
+
+  $ pip install "motor[encryption]"
+
+You can install all dependencies automatically with the following
+command::
+
+  $ pip install "motor[gssapi,aws,ocsp,snappy,srv,zstd,encryption]"
+
 See `requirements <https://motor.readthedocs.io/en/stable/requirements.html>`_
 for details about compatibility.
 

--- a/README.rst
+++ b/README.rst
@@ -103,37 +103,37 @@ asyncio. It requires:
 
 Optional dependencies:
 
-Motor supports same optional dependencies as PyMongo. Required dependencies can be installed 
+Motor supports same optional dependencies as PyMongo. Required dependencies can be installed
 along with Motor.
 
-GSSAPI authentication requires pymongo[gssapi]. The correct
+GSSAPI authentication requires ``gssapi`` extra dependency. The correct
 dependency can be installed automatically along with Motor::
 
   $ pip install "motor[gssapi]"
 
 similarly,
 
-MONGODB-AWS authentication requires pymongo[aws]::
+MONGODB-AWS authentication requires ``aws`` extra dependency::
 
   $ pip install "motor[aws]"
 
-Support for mongodb+srv:// URIs requires pymongo[srv]::
+Support for mongodb+srv:// URIs requires ``srv`` extra dependency::
 
   $ pip install "motor[srv]"
 
-OCSP requires pymongo[ocsp]::
+OCSP requires ``ocsp`` extra dependency::
 
   $ pip install "motor[ocsp]"
 
-Wire protocol compression with snappy requires pymongo[snappy]::
+Wire protocol compression with snappy requires ``snappy`` extra dependency::
 
   $ pip install "motor[snappy]"
 
-Wire protocol compression with zstandard requires pymongo[zstd]::
+Wire protocol compression with zstandard requires ``zstd`` extra dependency::
 
   $ pip install "motor[zstd]"
 
-Client-Side Field Level Encryption requires pymongo[encryption]::
+Client-Side Field Level Encryption requires ``encryption`` extra dependency::
 
   $ pip install "motor[encryption]"
 

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -14,3 +14,4 @@ The following is a list of people who have contributed to
 - Shane Harvey
 - Bulat Khasanov
 - William Zhou
+- Tushar Singh

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -24,40 +24,40 @@ asyncio. It requires:
 
 Optional dependencies:
 
-Motor supports same optional dependencies as PyMongo. Required dependencies can be installed 
+Motor supports same optional dependencies as PyMongo. Required dependencies can be installed
 along with Motor.
 
-GSSAPI authentication requires pymongo[gssapi]. The correct
+GSSAPI authentication requires ``gssapi`` extra dependency. The correct
 dependency can be installed automatically along with Motor::
 
   $ pip install "motor[gssapi]"
 
-similarly, 
+similarly,
 
-`MONGODB-AWS <https://pymongo.readthedocs.io/en/stable/examples/authentication.html#mongodb-aws>`_ 
-authentication requires pymongo[aws]::
+`MONGODB-AWS <https://pymongo.readthedocs.io/en/stable/examples/authentication.html#mongodb-aws>`_
+authentication requires ``aws`` extra dependency::
 
   $ pip install "motor[aws]"
 
-Support for mongodb+srv:// URIs requires pymongo[srv]::
+Support for mongodb+srv:// URIs requires ``srv`` extra dependency::
 
   $ pip install "motor[srv]"
 
-`OCSP <https://pymongo.readthedocs.io/en/stable/examples/tls.html#ocsp>`_ requires pymongo[ocsp]::
+`OCSP <https://pymongo.readthedocs.io/en/stable/examples/tls.html#ocsp>`_ requires ``ocsp`` extra dependency::
 
   $ pip install "motor[ocsp]"
 
-Wire protocol compression with snappy requires pymongo[snappy]::
+Wire protocol compression with snappy requires ``snappy`` extra dependency::
 
   $ pip install "motor[snappy]"
 
-Wire protocol compression with zstandard requires pymongo[zstd]::
+Wire protocol compression with zstandard requires ``zstd`` extra dependency::
 
   $ pip install "motor[zstd]"
 
-`Client-Side Field Level Encryption 
-<https://pymongo.readthedocs.io/en/stable/examples/encryption.html#client-side-field-level-encryption>`_ 
-requires pymongo[encryption]::
+`Client-Side Field Level Encryption
+<https://pymongo.readthedocs.io/en/stable/examples/encryption.html#client-side-field-level-encryption>`_
+requires ``encryption`` extra dependency::
 
   $ pip install "motor[encryption]"
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -12,6 +12,66 @@ To install Motor from sources, you can clone its git repository and do::
 
   $ python3 -m pip install .
 
+Dependencies
+------------
+
+Motor works in all the environments officially supported by Tornado or by
+asyncio. It requires:
+
+* Unix (including macOS) or Windows.
+* PyMongo_ >=3.12,<4
+* Python 3.5+
+
+Optional dependencies:
+
+Motor supports same optional dependencies as PyMongo. Required dependencies can be installed 
+along with Motor.
+
+GSSAPI authentication requires pymongo[gssapi]. The correct
+dependency can be installed automatically along with Motor::
+
+  $ pip install "motor[gssapi]"
+
+similarly, 
+
+`MONGODB-AWS <https://pymongo.readthedocs.io/en/stable/examples/authentication.html#mongodb-aws>`_ 
+authentication requires pymongo[aws]::
+
+  $ pip install "motor[aws]"
+
+Support for mongodb+srv:// URIs requires pymongo[srv]::
+
+  $ pip install "motor[srv]"
+
+`OCSP <https://pymongo.readthedocs.io/en/stable/examples/tls.html#ocsp>`_ requires pymongo[ocsp]::
+
+  $ pip install "motor[ocsp]"
+
+Wire protocol compression with snappy requires pymongo[snappy]::
+
+  $ pip install "motor[snappy]"
+
+Wire protocol compression with zstandard requires pymongo[zstd]::
+
+  $ pip install "motor[zstd]"
+
+`Client-Side Field Level Encryption 
+<https://pymongo.readthedocs.io/en/stable/examples/encryption.html#client-side-field-level-encryption>`_ 
+requires pymongo[encryption]::
+
+  $ pip install "motor[encryption]"
+
+You can install all dependencies automatically with the following
+command::
+
+  $ pip install "motor[gssapi,aws,ocsp,snappy,srv,zstd,encryption]"
+
+See `requirements <https://motor.readthedocs.io/en/stable/requirements.html>`_
+for details about compatibility.
+
+
 .. _PyPI: http://pypi.python.org/pypi/motor
 
 .. _pip: http://pip-installer.org
+
+.. _PyMongo: http://pypi.python.org/pypi/pymongo/

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ extras_require = {
     "zstd": ["pymongo[zstd]" + pymongo_ver],
     "aws": ["pymongo[aws]" + pymongo_ver],
     "srv": ["pymongo[srv]" + pymongo_ver],
+    "gssapi": ["pymongo[gssapi]" + pymongo_ver],
 }
 
 tests_require = ["mockupdb>=1.4.0"]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,14 @@ pymongo_ver = ">=3.12,<5"
 
 install_requires = ["pymongo" + pymongo_ver]
 
-extras_require = {"encryption": ["pymongo[encryption]" + pymongo_ver]}
+extras_require = {
+    "encryption": ["pymongo[encryption]" + pymongo_ver],
+    "ocsp": ["pymongo[ocsp]" + pymongo_ver],
+    "snappy": ["pymongo[snappy]" + pymongo_ver],
+    "zstd": ["pymongo[zstd]" + pymongo_ver],
+    "aws": ["pymongo[aws]" + pymongo_ver],
+    "srv": ["pymongo[srv]" + pymongo_ver],
+}
 
 tests_require = ["mockupdb>=1.4.0"]
 


### PR DESCRIPTION
Motor is a wrapper around Pymongo, extras available during pip install Pymongo should be available with Motor as well. I recently faced an issue regarding this and have raised it on Jira. 