### PR TITLE
MOTOR-979 Use asyncio.get_event_loop so that DeprecationWarnings are correctly issued

### DIFF
--- a/motor/frameworks/asyncio/__init__.py
+++ b/motor/frameworks/asyncio/__init__.py
@@ -24,7 +24,7 @@ import functools
 import multiprocessing
 import os
 import warnings
-from asyncio import coroutine  # noqa: F401 - For framework interface.
+from asyncio import coroutine, get_event_loop  # noqa: F401 - For framework interface.
 from concurrent.futures import ThreadPoolExecutor
 
 try:
@@ -34,14 +34,6 @@ except ImportError:
 
 
 CLASS_PREFIX = "AsyncIO"
-
-
-def get_event_loop():
-    try:
-        return asyncio.get_running_loop()
-    except RuntimeError:
-        # Workaround for bugs.python.org/issue39529.
-        return asyncio.get_event_loop_policy().get_event_loop()
 
 
 def is_event_loop(loop):


### PR DESCRIPTION
…issued


It looks like a workaround I wrote in Tornado was incorrectly incorporated into AsyncioMotorClient here https://github.com/mongodb/motor/pull/155/files#r851429040

if a user has opted into DeprecationWarnings as errors `asyncio.get_event_loop_policy().get_event_loop()` incorrectly suppresses the deprecation warning: 


``` graingert@superjacent  testing310  ~  python3.10 -Werror
Python 3.10.4 (main, Apr  8 2022, 17:35:13) [GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import motor.motor_asyncio
>>> client = motor.motor_asyncio.AsyncIOMotorClient()
>>> client.test.pages.drop()  # this should raise a DeprecationWarning because it was called without a running loop
<Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/lib/python3.10/asyncio/futures.py:384]>
>>> 
```