### PR TITLE
MOTOR-1014 Add __aenter__ and __aexit__ for AgnosticBaseCursor so that cursor can be instantiated using the context manager

### DIFF
--- a/motor/core.py
+++ b/motor/core.py
@@ -1252,6 +1252,13 @@ class AgnosticBaseCursor(AgnosticBase):
 
     __anext__ = next
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self.delegate:
+            await self.close()
+
     def _get_more(self):
         """Initial query or getMore. Returns a Future."""
         if not self.alive:

--- a/test/asyncio_tests/test_asyncio_cursor.py
+++ b/test/asyncio_tests/test_asyncio_cursor.py
@@ -568,18 +568,19 @@ class TestAsyncIOCursor(AsyncIOMockServerTestCase):
         find_raw_batches = partial(coll.find_raw_batches, {})
         agg_raw_batches = partial(coll.aggregate_raw_batches, [{"$sort": {"_id": 1}}])
         for method in find, agg, find_raw_batches, agg_raw_batches:
-            contract_cursor = method().batch_size(2)
+            contrast_cursor = method().batch_size(2)
             async with method().batch_size(2) as cursor:
                 self.assertFalse(cursor.started, "Cursor shouldn't start immediately")
-                await cursor.fetch_next
-                record = cursor.next_object()
+                with self.assertWarns(DeprecationWarning):
+                    await cursor.fetch_next
+                    record = cursor.next_object()
                 self.assertEqual({"_id": 0}, bson.decode_all(record)[0] if type(record) is bytes else record)
                 self.assertTrue(cursor.started)
                 self.assertFalse(cursor.closed)
-            self.assertFalse(contract_cursor.closed)
+            self.assertFalse(contrast_cursor.closed)
             self.assertTrue(cursor.closed)
-            await contract_cursor.close()
-            self.assertTrue(contract_cursor.closed)
+            await contrast_cursor.close()
+            self.assertTrue(contrast_cursor.closed)
 
 
 class TestAsyncIOCursorMaxTimeMS(AsyncIOTestCase):


### PR DESCRIPTION
When I use the following code:
```python
async with self.coll.find() as cursor:
    async for record in cursor:
        yield record
```
It's going to throw an AttributeError
So I added the asynchronous context manager method
so that I did not have to close the cursor when I was done with it