### PR TITLE
Update aiohttp example

### DIFF
--- a/doc/examples/aiohttp_example.py
+++ b/doc/examples/aiohttp_example.py
@@ -53,6 +53,6 @@ def main():
     app = init_connection()
     web.run_app(app)
 
-if __name__=='__main__':
+if __name__== "__main__":
     main()
 # -- main-end --

--- a/doc/examples/aiohttp_example.py
+++ b/doc/examples/aiohttp_example.py
@@ -1,3 +1,5 @@
+# These comments let tutorial-asyncio.rst include this code in sections.
+# -- setup-start --
 import asyncio
 
 from aiohttp import web
@@ -35,10 +37,14 @@ async def page_handler(request):
 
     return web.Response(body=document["body"].encode(), content_type="text/html")
 
+# -- handler-end --
+
+# -- main-start --
 async def init_connection():
     db = await setup_db()
     app = web.Application()
     app["db"] = db
+    # Route requests to the page_handler() coroutine.
     app.router.add_get("/pages/{page_name}", page_handler)
     return app
 
@@ -48,3 +54,4 @@ def main():
 
 if __name__=='__main__':
     main()
+# -- main-end --

--- a/doc/examples/aiohttp_example.py
+++ b/doc/examples/aiohttp_example.py
@@ -37,6 +37,7 @@ async def page_handler(request):
 
     return web.Response(body=document["body"].encode(), content_type="text/html")
 
+
 # -- handler-end --
 
 # -- main-start --

--- a/doc/examples/aiohttp_example.py
+++ b/doc/examples/aiohttp_example.py
@@ -53,6 +53,6 @@ def main():
     app = init_connection()
     web.run_app(app)
 
-if __name__== "__main__":
+if __name__ == "__main__":
     main()
 # -- main-end --

--- a/doc/examples/aiohttp_example.py
+++ b/doc/examples/aiohttp_example.py
@@ -1,7 +1,5 @@
 # These comments let tutorial-asyncio.rst include this code in sections.
 # -- setup-start --
-import asyncio
-
 from aiohttp import web
 
 from motor.motor_asyncio import AsyncIOMotorClient

--- a/doc/examples/aiohttp_example.py
+++ b/doc/examples/aiohttp_example.py
@@ -1,5 +1,3 @@
-# These comments let tutorial-asyncio.rst include this code in sections.
-# -- setup-start --
 import asyncio
 
 from aiohttp import web
@@ -37,14 +35,16 @@ async def page_handler(request):
 
     return web.Response(body=document["body"].encode(), content_type="text/html")
 
+async def init_connection():
+    db = await setup_db()
+    app = web.Application()
+    app["db"] = db
+    app.router.add_get("/pages/{page_name}", page_handler)
+    return app
 
-# -- handler-end --
+def main():
+    app = init_connection()
+    web.run_app(app)
 
-# -- main-start --
-db = asyncio.run(setup_db())
-app = web.Application()
-app["db"] = db
-# Route requests to the page_handler() coroutine.
-app.router.add_get("/pages/{page_name}", page_handler)
-web.run_app(app)
-# -- main-end --
+if __name__=='__main__':
+    main()

--- a/doc/examples/aiohttp_example.py
+++ b/doc/examples/aiohttp_example.py
@@ -49,9 +49,11 @@ async def init_connection():
     app.router.add_get("/pages/{page_name}", page_handler)
     return app
 
+
 def main():
     app = init_connection()
     web.run_app(app)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hi,

For a newbie to motor and asyncio the code proposed here would not work especially for python3.9 onwards. asyncio automatically closes the event loop at the end of asyncio.run() method. Subsequently the aiohttp is not able to open new event loop[issue is faced on all platforms: windows, linux, mac_os]. Proposed are the changes works and ensures that the event loop is consistent among aiohttp and motor's event loop