### PR TITLE
MOTOR-1164 Update MongoClient import path

### DIFF
--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -17,3 +17,4 @@ The following is a list of people who have contributed to
 - Tushar Singh
 - Steven Silvester
 - Julius Park
+- Fergus Strangways-Dixon

--- a/motor/core.py
+++ b/motor/core.py
@@ -23,7 +23,6 @@ import pymongo.auth
 import pymongo.common
 import pymongo.database
 import pymongo.errors
-import pymongo.mongo_client
 from pymongo.change_stream import ChangeStream
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
@@ -99,7 +98,7 @@ class AgnosticBaseProperties(AgnosticBase):
 
 class AgnosticClient(AgnosticBaseProperties):
     __motor_class_name__ = "MotorClient"
-    __delegate_class__ = pymongo.mongo_client.MongoClient
+    __delegate_class__ = pymongo.MongoClient
 
     address = ReadOnlyProperty()
     arbiters = ReadOnlyProperty()
@@ -127,7 +126,7 @@ class AgnosticClient(AgnosticBaseProperties):
         """Create a new connection to a single MongoDB instance at *host:port*.
 
         Takes the same constructor arguments as
-        :class:`~pymongo.mongo_client.MongoClient`, as well as:
+        :class:`~pymongo.MongoClient`, as well as:
 
         :Parameters:
           - `io_loop` (optional): Special event loop

--- a/test/tornado_tests/test_motor_client.py
+++ b/test/tornado_tests/test_motor_client.py
@@ -23,7 +23,6 @@ from test.tornado_tests import MotorMockServerTest, MotorTest, remove_all_users
 from test.utils import get_primary_pool, one
 
 import pymongo
-import pymongo.mongo_client
 from bson import CodecOptions
 from mockupdb import OpQuery
 from pymongo import CursorType, ReadPreference, WriteConcern
@@ -83,7 +82,7 @@ class MotorClientTest(MotorTest):
             motor.MotorClient(test.env.uri, io_loop="foo")
 
     def test_database_named_delegate(self):
-        self.assertTrue(isinstance(self.cx.delegate, pymongo.mongo_client.MongoClient))
+        self.assertTrue(isinstance(self.cx.delegate, pymongo.MongoClient))
         self.assertTrue(isinstance(self.cx["delegate"], motor.MotorDatabase))
 
     @gen_test


### PR DESCRIPTION
Pymongo [recommends](https://pymongo.readthedocs.io/en/stable/tutorial.html#making-a-connection-with-mongoclient) importing the MongoClient from the top level module

[dd-trace-py relies on this import path](https://github.com/DataDog/dd-trace-py/blob/926a210494dd6ea0f396a890bcbf6033c45d4e74/ddtrace/contrib/pymongo/patch.py#L36) to properly instrument the client in Datadog

Patching the deeper-import results in errors creating the class as can be seen [here](https://github.com/DataDog/dd-trace-py/pull/6343)

Motor should import the client from the recommended location