### PR TITLE
PYTHON-4040 Pin testing to aiohttp<3.8.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ srv = [
     "pymongo[srv]>=4.5,<5",
 ]
 test = [
-    "pytest>=7", "mockupdb", "tornado>=5", "aiohttp", "motor[encryption]"
+    "pytest>=7", "mockupdb", "tornado>=5", "aiohttp<3.8.6", "motor[encryption]"
 ]
 zstd = [
     "pymongo[zstd]>=4.5,<5",


### PR DESCRIPTION
Our tests break when we leverage `aiohttp>=3.8.6` tests will fail. 