### PR TITLE
MOTOR-1298 Type `resume_token` as a property

### DIFF
--- a/motor/core.pyi
+++ b/motor/core.pyi
@@ -773,6 +773,7 @@ class AgnosticChangeStream(AgnosticBase, Generic[_DocumentType]):
     __delegate_class__: type[ChangeStream]
 
     async def _close(self) -> None: ...
+    @property
     def resume_token(self) -> Optional[Mapping[str, Any]]: ...
     def __init__(
         self,


### PR DESCRIPTION
This is what `pymongo` has :)

https://github.com/mongodb/mongo-python-driver/blob/8f7b86f3f39c31981cd860313c1141bce88ade26/pymongo/change_stream.py#L274