### PR TITLE
PYTHON-4499 Fix test_logging_without_listeners

### DIFF
--- a/synchro/__init__.py
+++ b/synchro/__init__.py
@@ -405,6 +405,7 @@ class MongoClient(Synchro, Generic[_T]):
     _kill_cursors_executor = SynchroProperty()
     _topology_settings = SynchroProperty()
     _process_periodic_tasks = SynchroProperty()
+    _event_listeners = SynchroProperty()
 
 
 class _SynchroTransactionContext(Synchro):


### PR DESCRIPTION
Fixes:
```
FAILED test/test_logger.py::TestLogger::test_logging_without_listeners - AttributeError: MotorClient has no attribute '_event_listeners'. To access the _event_listeners database, use client['_event_listeners'].
```