### PR TITLE
PYTHON-5892 fix broken link

### DIFF
--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -86,7 +86,7 @@ Use `the PyMongo compatibility matrix`_ to determine what MongoDB version is
 supported by PyMongo. Use the compatibility matrix above to determine what
 MongoDB version Motor supports.
 
-.. _the PyMongo compatibility matrix: https://www.mongodb.com/docs/languages/python/pymongo-driver/current/reference/compatibility/
+.. _the PyMongo compatibility matrix: https://www.mongodb.com/docs/drivers/compatibility/?driver-language=python&python-driver-framework=pymongo
 
 Motor and Tornado
 `````````````````


### PR DESCRIPTION
[PYTHON-5892](https://jira.mongodb.org/projects/PYTHON/issues/PYTHON-5892)
replace https://www.mongodb.com/docs/languages/python/pymongo-driver/current/reference/compatibility/ with https://www.mongodb.com/docs/drivers/compatibility/?driver-language=python&python-driver-framework=pymongo 