### PR TITLE
MOTOR-1481 Pin PyMongo version for synchro tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -147,7 +147,7 @@ allowlist_externals =
 setenv =
     PYTHONPATH = {envtmpdir}/mongo-python-driver
 commands =
-    git clone --depth 1 --branch master https://github.com/mongodb/mongo-python-driver {envtmpdir}/mongo-python-driver
+    git clone --depth 1 --branch 4.17.0 https://github.com/mongodb/mongo-python-driver {envtmpdir}/mongo-python-driver
     python -m pip install -e {envtmpdir}/mongo-python-driver
     python -m synchro.synchrotest {envtmpdir}/mongo-python-driver -v {posargs}
 
@@ -162,7 +162,7 @@ passenv =
 setenv =
     PYTHONPATH = {envtmpdir}/mongo-python-driver
 commands =
-    git clone --depth 1 --branch master https://github.com/mongodb/mongo-python-driver {envtmpdir}/mongo-python-driver
+    git clone --depth 1 --branch 4.17.0 https://github.com/mongodb/mongo-python-driver {envtmpdir}/mongo-python-driver
     python -m pip install -e {envtmpdir}/mongo-python-driver
     python -m synchro.synchrotest {envtmpdir}/mongo-python-driver -m auth -v test/test_auth.py
 


### PR DESCRIPTION
MOTOR-1481

## Summary
- Pin the PyMongo checkout used in the `synchro` and `enterprise-synchro` tox environments to the `4.17.0` tag instead of `master`.